### PR TITLE
Correct rare boss markers for LBRS

### DIFF
--- a/AtlasLootClassic_DungeonsAndRaids/data.lua
+++ b/AtlasLootClassic_DungeonsAndRaids/data.lua
@@ -3020,7 +3020,8 @@ data["LowerBlackrockSpire"] = {
 			npcID = 10263,
 			Level = {56, 57},
 			DisplayIDs = {{5047}},
-			AtlasMapBossID = "1'",
+			AtlasMapBossID = 1,
+			specialType = "rare",
 			[NORMAL_DIFF] = {
 				{ 1,  13181 }, -- Demonskin Gloves
 				{ 2,  13182 }, -- Phase Blade
@@ -3073,6 +3074,7 @@ data["LowerBlackrockSpire"] = {
 			Level = {57, 58},
 			DisplayIDs = {{11578}},
 			AtlasMapBossID = 6,
+			specialType = "rare",
 			[NORMAL_DIFF] = {
 				{ 1,  13282 }, -- Ogreseer Tower Boots
 				{ 2,  13283 }, -- Magus Ring
@@ -3163,7 +3165,6 @@ data["LowerBlackrockSpire"] = {
 			Level = 60,
 			DisplayIDs = {{11583}},
 			AtlasMapBossID = 15,
-			specialType = "rare",
 			[NORMAL_DIFF] = {
 				{ 1,  16670 }, -- Boots of Elements
 				{ 3,  13258 }, -- Slaghide Gauntlets


### PR DESCRIPTION
Mark **Burning Felguard** and **Spirestone Lord Magus** as rare.
Remove rare marker for **Urok Doomhowl**.

Urok Doomhowl is a summoned boss and can be done every run. He is not a rare spawn.