### PR TITLE
Avoid unnecessary hooks and API calls

### DIFF
--- a/AtlasLootClassic/Core/Tooltip.lua
+++ b/AtlasLootClassic/Core/Tooltip.lua
@@ -134,4 +134,7 @@ local function AddText(self)
 		self:AddLine(PLAYER_GUID_REGISTER[guid])
 	end
 end
-Tooltip:AddHookFunction("OnTooltipSetUnit", AddText)
+
+if GetRealmName() == "Lucifron" then
+	Tooltip:AddHookFunction("OnTooltipSetUnit", AddText)
+end


### PR DESCRIPTION
Only create silly tooltip hook when on addon author's realm.

I was only able to find one character named **Lag** on EU realms on Warcraft Logs. Guessing **Lucifron** is correct.

`GetRealmName()` is available as soon as the addon loads, so no waiting for events should be needed.