### PR TITLE
Added Headless Horseman to SM GY

### DIFF
--- a/AtlasLootClassic_DungeonsAndRaids/data.lua
+++ b/AtlasLootClassic_DungeonsAndRaids/data.lua
@@ -1243,6 +1243,7 @@ data["ScarletMonasteryGraveyard"] = {
 				{ 3,  7684 }, -- Bloodmage Mantle
 			},
 		},
+--@version-bcc@
         { -- SMHeadlessHorseman
             name = AL["Headless Horseman"],
             npcID = 23682,
@@ -1265,6 +1266,7 @@ data["ScarletMonasteryGraveyard"] = {
                 { 24, 33154 }, -- Sinister Squashling
             }
         },
+--@end-version-bcc@
 		{ -- SMGTrash
 			name = AL["Trash"],
 			ExtraList = true,

--- a/AtlasLootClassic_DungeonsAndRaids/data.lua
+++ b/AtlasLootClassic_DungeonsAndRaids/data.lua
@@ -1243,6 +1243,27 @@ data["ScarletMonasteryGraveyard"] = {
 				{ 3,  7684 }, -- Bloodmage Mantle
 			},
 		},
+        { -- SMHeadlessHorseman
+            name = AL["Headless Horseman"],
+            npcID = 23682,
+            Level = 70,
+            DisplayIDs = {{22351}},
+            AtlasMapBossID = nil,
+            [NORMAL_DIFF] = {
+                { 1,  34075 }, -- Ring of Ghoulish Delight
+                { 2,  34073 }, -- The Horseman's Signet Ring
+                { 3,  34074 }, -- Witches Band
+                { 5,  33808 }, -- The Horseman's Helm
+                { 6,  38175 }, -- The Horseman's Blade
+                { 8,  34068 }, -- Weighted Jack-o'-Lantern
+                { 16,  37012 }, -- The Horseman's Reins
+                { 18,  33182 }, -- Swift Flying Broom        280% flying
+                { 19,  33176 }, -- Flying Broom              60% flying
+                { 21,  33184 }, -- Swift Magic Broom         100% ground
+                { 22,  37011 }, -- Magic Broom               60% ground
+                { 24,  33154 }, -- Sinister Squashling
+            }
+        },
 		{ -- SMGTrash
 			name = AL["Trash"],
 			ExtraList = true,

--- a/AtlasLootClassic_DungeonsAndRaids/data.lua
+++ b/AtlasLootClassic_DungeonsAndRaids/data.lua
@@ -1250,6 +1250,7 @@ data["ScarletMonasteryGraveyard"] = {
             Level = 70,
             DisplayIDs = {{22351}},
             AtlasMapBossID = nil,
+			ExtraList = true,
             [NORMAL_DIFF] = {
                 { 1,  34075 }, -- Ring of Ghoulish Delight
                 { 2,  34073 }, -- The Horseman's Signet Ring

--- a/AtlasLootClassic_DungeonsAndRaids/data.lua
+++ b/AtlasLootClassic_DungeonsAndRaids/data.lua
@@ -1255,13 +1255,14 @@ data["ScarletMonasteryGraveyard"] = {
                 { 3,  34074 }, -- Witches Band
                 { 5,  33808 }, -- The Horseman's Helm
                 { 6,  38175 }, -- The Horseman's Blade
-                { 8,  34068 }, -- Weighted Jack-o'-Lantern
-                { 16,  37012 }, -- The Horseman's Reins
-                { 18,  33182 }, -- Swift Flying Broom        280% flying
-                { 19,  33176 }, -- Flying Broom              60% flying
-                { 21,  33184 }, -- Swift Magic Broom         100% ground
-                { 22,  37011 }, -- Magic Broom               60% ground
-                { 24,  33154 }, -- Sinister Squashling
+                { 8,  33292 }, -- Hallowed Helm
+                { 9,  34068 }, -- Weighted Jack-o'-Lantern
+                { 16, 37012 }, -- The Horseman's Reins
+                { 18, 33182 }, -- Swift Flying Broom        280% flying
+                { 19, 33176 }, -- Flying Broom              60% flying
+                { 21, 33184 }, -- Swift Magic Broom         100% ground
+                { 22, 37011 }, -- Magic Broom               60% ground
+                { 24, 33154 }, -- Sinister Squashling
             }
         },
 		{ -- SMGTrash


### PR DESCRIPTION
Headless Horseman was added in 2.2.2. Added all loot that was in the game during TBC (2.2.2-2.4.3):
- [Ring of Ghoulish Delight (34075)](https://tbc.wowhead.com/item=34075/ring-of-ghoulish-delight) – Physical DPS ring
- [The Horseman's Signet (34073)](https://tbc.wowhead.com/item=34073/the-horsemans-signet-ring) – Caster DPS ring
- [Witches Band (34074)](https://tbc.wowhead.com/item=34074/witches-band) – Healer ring
- [The Horseman's Helm (33808)](https://tbc.wowhead.com/item=33808/the-horsemans-helm) – Plate helm
- [The Horseman's Blade (38175)](https://tbc.wowhead.com/item=38175/the-horsemans-blade) – 1H Agi/AP sword
- [Hallowed Helm (33292)](https://tbc.wowhead.com/item=33292/hallowed-helm) – Vanity helm
- [Weighted Jack-o'-Lantern (34068)](https://tbc.wowhead.com/item=34068/weighted-jack-o-lantern) – Vanity item
- [The Horseman's Reins (37012)](https://tbc.wowhead.com/item=37012/the-horsemans-reins) – Horse mount
- [Swift Flying Broom (33182)](https://tbc.wowhead.com/item=33182/swift-flying-broom) – 280% flying mount
- [Flying Broom (33176)](https://tbc.wowhead.com/item=33176/flying-broom) – 60% flying mount
- [Swift Magic Broom (33184)](https://tbc.wowhead.com/item=33184/swift-magic-broom) – 100% ground mount
- [Magic Broom (37011)](https://tbc.wowhead.com/item=37011/magic-broom) – 60% ground mount
- [Sinister Squashling (33154)](https://tbc.wowhead.com/item=33154/sinister-squashling) – Pet

Will be relevant once Hallow's End comes around.