### PR TITLE
Add missing feasts and special achievement foods

### DIFF
--- a/AtlasLootClassic_Crafting/data-wrath.lua
+++ b/AtlasLootClassic_Crafting/data-wrath.lua
@@ -2054,8 +2054,8 @@ data["CookingWrath"] = {
 			name = AL["Feast"],
 			[NORMAL_DIFF] = {
 				{ 1, 45554 },	-- Great Feast
-				{ 16, 57423 },	-- Fish Feast
 				{ 3, 58528 },   -- Small Feast
+				{ 16, 57423 },	-- Fish Feast
 				{ 18, 58527 },  -- Gigantic Feast
 			},
 		},
@@ -2081,10 +2081,10 @@ data["CookingWrath"] = {
 			[NORMAL_DIFF] = {
 				{ 1, 57438 },	-- Blackened Worg Steak
 				{ 2, 57443 },	-- Tracker Snacks
-				{ 16, 57435 },	-- Critter Bites
 				{ 4, 58523 },   -- Bad Clams
-				{ 19, 58525 },  -- Haunted Herring
 				{ 5, 58521 },   -- Last Week's Mammoth
+				{ 16, 57435 },	-- Critter Bites
+				{ 19, 58525 },  -- Haunted Herring
 				{ 20, 58512 },  -- Tasty Cupcake
 			},
 		},

--- a/AtlasLootClassic_Crafting/data-wrath.lua
+++ b/AtlasLootClassic_Crafting/data-wrath.lua
@@ -2055,6 +2055,8 @@ data["CookingWrath"] = {
 			[NORMAL_DIFF] = {
 				{ 1, 45554 },	-- Great Feast
 				{ 16, 57423 },	-- Fish Feast
+				{ 3, 58528 },   -- Small Feast
+				{ 18, 58527 },  -- Gigantic Feast
 			},
 		},
 		{
@@ -2080,6 +2082,10 @@ data["CookingWrath"] = {
 				{ 1, 57438 },	-- Blackened Worg Steak
 				{ 2, 57443 },	-- Tracker Snacks
 				{ 16, 57435 },	-- Critter Bites
+				{ 4, 58523 },   -- Bad Clams
+				{ 19, 58525 },  -- Haunted Herring
+				{ 5, 58521 },   -- Last Week's Mammoth
+				{ 20, 58512 },  -- Tasty Cupcake
 			},
 		},
 	}


### PR DESCRIPTION
Added missing feasts:

[Small Feast](https://www.wowhead.com/wotlk/spell=58528/small-feast)
[Gigantic Feast](https://www.wowhead.com/wotlk/spell=58527/gigantic-feast)

Added missing "Special" achievement foods:

[Bad Clams](https://www.wowhead.com/wotlk/spell=58523/bad-clams)
[Last Weeks Mammoth](https://www.wowhead.com/wotlk/spell=58521/last-weeks-mammoth)
[Haunted Herring](https://www.wowhead.com/wotlk/spell=58525/haunted-herring)
[Tasty Cupcake](https://www.wowhead.com/wotlk/spell=58512/tasty-cupcake)