### PR TITLE
Fix Button and Gradient Creation - WotLK Patch 3.4.1

### DIFF
--- a/AtlasLootClassic/Addons/Favourites_GUI.lua
+++ b/AtlasLootClassic/Addons/Favourites_GUI.lua
@@ -341,7 +341,7 @@ local function Slot_CreateSlotButton(parFrame, slotID, modelFrame)
     frame:RegisterForClicks("AnyDown")
 
 	-- secButtonTexture <texture>
-	frame.icon = frame:CreateTexture(nil, frame)
+	frame.icon = frame:CreateTexture(nil)
 	frame.icon:SetAllPoints(frame)
 
 	-- secButtonOverlay <texture>

--- a/AtlasLootClassic/Button/Button.lua
+++ b/AtlasLootClassic/Button/Button.lua
@@ -239,7 +239,7 @@ function Button:Create()
 	button.highlightBg:SetPoint("TOPLEFT", button, "TOPLEFT", 0, 0)
 	button.highlightBg:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT", -(button:GetWidth()/2), 0)
 	button.highlightBg:SetColorTexture(1,0,0)
-	button.highlightBg:SetGradientAlpha("HORIZONTAL", 1, 1, 1, 0.45, 1, 1, 1, 0)
+	button.highlightBg:SetGradient("HORIZONTAL", CreateColor(1, 1, 1, 0.45), CreateColor(1, 1, 1, 0))
 	button.highlightBg:Hide()
 
 	-- Icon <texture>
@@ -347,7 +347,7 @@ function Button:Create()
 	button.secButton:RegisterForClicks("AnyDown")
 
 	-- secButtonTexture <texture>
-	button.secButton.icon = button.secButton:CreateTexture(buttonName.."_secButtonIcon", button.secButton)
+	button.secButton.icon = button.secButton:CreateTexture(buttonName.."_secButtonIcon")
 	button.secButton.icon:SetDrawLayer("ARTWORK", 0)
 	button.secButton.icon:SetAllPoints(button.secButton)
 	button.secButton.icon:SetTexture("Interface\\Icons\\INV_Misc_QuestionMark")
@@ -417,7 +417,7 @@ function Button:Create()
 	button.secButton.favourite:Hide()
 
 	-- factionIcon
-	button.factionIcon = button:CreateTexture(buttonName.."_factionIcon", button)
+	button.factionIcon = button:CreateTexture(buttonName.."_factionIcon")
 	button.factionIcon:SetPoint("RIGHT", button.secButton, "LEFT", -2, 0)
 	button.factionIcon:SetHeight(28)
 	button.factionIcon:SetWidth(28)
@@ -458,7 +458,7 @@ function Button:CreateSecOnly(frame)
 	button.secButton:RegisterForClicks("AnyDown")
 
 	-- secButtonTexture <texture>
-	button.secButton.icon = button.secButton:CreateTexture(buttonName.."_secButtonIcon", button.secButton)
+	button.secButton.icon = button.secButton:CreateTexture(buttonName.."_secButtonIcon")
 	button.secButton.icon:SetDrawLayer("ARTWORK", 0)
 	button.secButton.icon:SetAllPoints(button.secButton)
 	button.secButton.icon:SetTexture("Interface\\Icons\\INV_Misc_QuestionMark")


### PR DESCRIPTION
```
Message: Interface/AddOns/AtlasLootClassic/Button/Button.lua:242: attempt to call method 'SetGradientAlpha' (a nil value)
Time: Tue Jan 17 22:10:21 2023
Count: 1
Stack: Interface/AddOns/AtlasLootClassic/Button/Button.lua:242: attempt to call method 'SetGradientAlpha' (a nil value)
[string "@Interface/AddOns/AtlasLootClassic/Button/Button.lua"]:242: in function `Create'
[string "@Interface/AddOns/AtlasLootClassic/GUI/ItemFrame.lua"]:47: in function `Create'
[string "@Interface/AddOns/AtlasLootClassic/GUI/GUI.lua"]:1394: in function `Create'
[string "@Interface/AddOns/AtlasLootClassic/GUI/GUI.lua"]:956: in function `func'
[string "@Interface/AddOns/AtlasLootClassic/AtlasLoot.lua"]:42: in function <Interface/AddOns/AtlasLootClassic/AtlasLoot.lua:34>
```

```
Message: bad argument #3 to '?' (Usage: local texture = self:CreateTexture([name, drawLayer, templateName, subLevel]))
Time: Tue Jan 17 22:11:42 2023
Count: 1
Stack: bad argument #3 to '?' (Usage: local texture = self:CreateTexture([name, drawLayer, templateName, subLevel]))
[string "=[C]"]: in function `CreateTexture'
[string "@Interface/AddOns/AtlasLootClassic/Button/Button.lua"]:350: in function `Create'
[string "@Interface/AddOns/AtlasLootClassic/GUI/ItemFrame.lua"]:47: in function `Create'
[string "@Interface/AddOns/AtlasLootClassic/GUI/GUI.lua"]:1394: in function `Create'
[string "@Interface/AddOns/AtlasLootClassic/GUI/GUI.lua"]:956: in function `func'
[string "@Interface/AddOns/AtlasLootClassic/AtlasLoot.lua"]:42: in function <Interface/AddOns/AtlasLootClassic/AtlasLoot.lua:34>
```