### PR TITLE
Fixes error when trying to retrieve favourite list name from a global list

### DIFF
--- a/AtlasLootClassic/Addons/Favourites.lua
+++ b/AtlasLootClassic/Addons/Favourites.lua
@@ -826,7 +826,7 @@ function Favourites:GetFavouriteListText(listName, itemCount)
 end
 
 function Favourites:GetFavouriteItemText(itemId, listId)
-    local listData = self.db.lists[listId]
+    local listData = self.db.lists[listId] or self.globalDb.lists[listId]
     local obsolete = self:IsItemEquippedOrObsolete(itemId, listId)
     local text = ""
     if obsolete then


### PR DESCRIPTION
Fixed favorite tooltip issue
Fix https://github.com/Hoizame/AtlasLootClassic/issues/311

I have multiple favourite lists for my different characters as global lists. Without this, when hovering over an item in a list (and having list names in tooltips enabled) I'd get the following error:

```
Message: ...erface/AddOns/AtlasLootClassic/Addons/Favourites.lua:835: attempt to index local 'listData' (a nil value)
Time: Thu Jan 19 17:48:25 2023
Count: 7
Stack: ...erface/AddOns/AtlasLootClassic/Addons/Favourites.lua:835: attempt to index local 'listData' (a nil value)
[string "=(tail call)"]: ?
[string "=[C]"]: ?
[string "@Interface/AddOns/AtlasLootClassic/Addons/Favourites.lua"]:835: in function `GetFavouriteItemText'
[string "@Interface/AddOns/AtlasLootClassic/Addons/Favourites.lua"]:349: in function <...erface/AddOns/AtlasLootClassic/Addons/Favourites.lua:327>
[string "=[C]"]: ?
[string "=[C]"]: ?
[string "=[C]"]: ?
[string "=[C]"]: ?
[string "=[C]"]: ?
[string "=[C]"]: ?
[string "@Interface/AddOns/LoonBestInSlot/UpdateTooltips.lua"]:187: in function <Interface/AddOns/LoonBestInSlot/UpdateTooltips.lua:181>
[string "=[C]"]: ?
[string "=[C]"]: in function `SetItemByID'
[string "@Interface/AddOns/AtlasLootClassic/Button/Item_type.lua"]:218: in function `OnEnter'
[string "@Interface/AddOns/AtlasLootClassic/Addons/Favourites_GUI.lua"]:247: in function <...ce/AddOns/AtlasLootClassic/Addons/Favourites_GUI.lua:245>

Locals: (*temporary) = true
(*temporary) = <function> defined =[C]:-1
```

This was due to the tooltip function only trying to find the list in the per-character list, and not the global lists.