### PR TITLE
Fix for index nil value

### DIFF
--- a/AtlasLootClassic/Addons/Favourites.lua
+++ b/AtlasLootClassic/Addons/Favourites.lua
@@ -836,12 +836,17 @@ function Favourites:CountFavouritesByList(addonName, contentName, boss, dif, inc
         ItemCountCache[cacheIdent] = result
         return result
     end
+    
     -- Get count for all matching items
     local items, tableType, diffData = ItemDB:GetItemTable(addonName, contentName, boss, dif)
+    -- Check if items is nil or empty
+    if not items or next(items) == nil then
+        return
+    end
+
     for l, listData in pairs(self.db.lists) do
         local listName = listData.__name
-        for i = 1, #items do
-            local item = items[i]
+        for i, item in ipairs(items) do
             if type(item[2]) == "number" then
                 local itemID = item[2]
                 if listData[itemID] and (includeObsolete or not self:IsItemEquippedOrObsolete(itemID, l)) then
@@ -850,10 +855,10 @@ function Favourites:CountFavouritesByList(addonName, contentName, boss, dif, inc
             end
         end
     end
+    
     for l, listData in pairs(self.globalDb.lists) do
         local listName = listData.__name
-        for i = 1, #items do
-            local item = items[i]
+        for i, item in ipairs(items) do
             if type(item[2]) == "number" then
                 local itemID = item[2]
                 if listData[itemID] and (includeObsolete or not self:IsItemEquippedOrObsolete(itemID, l)) then
@@ -862,6 +867,7 @@ function Favourites:CountFavouritesByList(addonName, contentName, boss, dif, inc
             end
         end
     end
+    
     ItemCountCache[cacheIdent] = result
     return result
 end


### PR DESCRIPTION
function Favourites:CountFavouritesByList often resulted in a "attempt to index local 'item' (a nil value)" error for me, which in turn meant I couldn't see any of the items in the collections area. This fix introduces 2 things:
1. Check if items is nil or empty
2. By using ipairs, we ensure that we only iterate over non-nil values in the items table.