### PR TITLE
Update Vendor Data for wrath p3 (3.4.2 patch)

### DIFF
--- a/AtlasLootClassic/Data/VendorPrice.lua
+++ b/AtlasLootClassic/Data/VendorPrice.lua
@@ -48,6 +48,7 @@ local PRICE_INFO_LIST = {
     ["EmblemOfTriumph"] = { currencyID = 301 }, -- Emblem of Triumph
     ["EmblemOfConquest"] = { currencyID = 221 }, -- Emblem of Conquest
     ["EmblemOfFrost"] = { currencyID = 341 }, -- Emblem of Frost
+    ["SiderealEssence"] = { currencyID = 2589 }, -- Sidereal Essence
 
     ["cpvpAlterac"] = { currencyID = 121 }, -- Alterac Valley Mark of Honor
 	["cpvpWarsong"] = { currencyID = 125 }, -- Warsong Gulch Mark of Honor

--- a/AtlasLootClassic_Collections/data-wrath.lua
+++ b/AtlasLootClassic_Collections/data-wrath.lua
@@ -541,6 +541,11 @@ data["EmblemofTriumph"] = {
 			name = AL["Misc"],
 			[NORMAL_DIFF] = {
 				{ 1, 47556 }, -- Crusader Orb
+				{ 2, 44713 }, -- Ebon Blade Commendation Badge
+				{ 3, 44711 }, -- Argent Crusade Commendation Badge
+				{ 4, 44710 }, -- Wyrmrest Commendation Badge
+				{ 5, 43950 }, -- Kirin Tor Commendation Badge
+				{ 6, 49702 }, -- Sons of Hodir Commendation Badge
 			},
 		},
 	}

--- a/AtlasLootClassic_Collections/data-wrath.lua
+++ b/AtlasLootClassic_Collections/data-wrath.lua
@@ -654,6 +654,131 @@ data["EmblemofFrost"] = {
 	}
 }
 
+data["SiderealEssence"] = {
+	name = format(AL["'%s' Vendor"], AL["Sidereal Essence"]),
+	ContentType = VENDOR_CONTENT,
+	TableType = NORMAL_ITTYPE,
+	gameVersion = AtlasLoot.WRATH_VERSION_NUM,
+	items = {
+		{
+			name = ALIL["Armor"].." - "..ALIL["Cloth"],
+			[NORMAL_DIFF] = {
+				{ 1, 46068 }, -- Amice of Inconceivable Horror
+				{ 3, 46050 }, -- Starlight Treads
+				{16, 46045 }, -- Pulsar Gloves
+				{18, 46034 }, -- Leggings of Profound Darkness
+			},
+		},
+		{
+			name = ALIL["Armor"].." - "..ALIL["Leather"],
+			[NORMAL_DIFF] = {
+				{ 1, 46095 }, -- Soul-Devouring Cinch
+				{ 2, 45455 }, -- Belt of the Crystal Tree
+				{ 4, 45869 }, -- Fluxing Energy Coils
+				{ 6, 45993 }, -- Mimiron's Flight Goggles
+				{16, 46043 }, -- Gloves of the Endless Dark
+				{17, 45293 }, -- Handguards of Potent Cures
+				{19, 46049 }, -- Zodiac Leggings
+			},
+		},
+		{
+			name = ALIL["Armor"].." - "..ALIL["Mail"],
+			[NORMAL_DIFF] = {
+				{ 1, 46044 }, -- Observer's Mantle
+				{ 2, 45300 }, -- Mantle of Fiery Vengeance
+				{ 4, 45867 }, -- Breastplate of the Stoneshaper
+				{16, 45989 }, -- Tempered Mercury Greaves
+				{19, 45943 }, -- Gloves of Whispering Winds
+			},
+		},
+		{
+			name = ALIL["Armor"].." - "..ALIL["Plate"],
+			[NORMAL_DIFF] = {
+				{ 1, 45295 }, -- Gilded Steel Legplates
+				{ 2, 45982 }, -- Fused Alloy Legplates
+				{ 4, 45888 }, -- Bitter Cold Armguards
+				{ 6, 46037 }, -- Shoulderplates of the Celestial Wrath
+				{ 8, 45928 }, -- Gauntlets of the Thunder God
+				{16, 45988 }, -- Greaves of the Iron Army
+				{19, 46039 }, -- Breastplate of the Timeless
+				{21, 46041 }, -- Starfall Girdle
+			},
+		},
+		{
+			name = ALIL["Weapon"],
+			[NORMAL_DIFF] = {
+				{ 1, 46097 }, -- Caress of Insanity
+				{ 2, 45294 }, -- Petrified Ivy Sprig
+				{ 3, 45868 }, -- Aesir's Edge
+				{ 4, 46035 }, -- Aesuga, Hand of the Ardent Champion
+				{ 5, 45886 }, -- Icecore Staff
+				{ 6, 45947 }, -- Serilas, Blood Blade of Invar One-Arm
+				{ 7, 45990 }, -- Fusion Blade
+				{ 8, 46067 }, -- Hammer of Crushing Whispers
+				{ 9, 46036 }, -- Void Sabre
+				{10, 45296 }, -- Twirling Blades
+				{11, 45449 }, -- The Masticator
+				{12, 45930 }, -- Combatant's Bootblade
+				{13, 45876 }, -- Shiver
+				{14, 45870 }, -- Magnetized Projectile Emitter
+				{15, 46033 }, -- Tortured Earth
+				{16, 45448 }, -- Perilous Bite
+			},
+		},
+		{
+			name = ALIL["Shield"],
+			[NORMAL_DIFF] = {
+				{ 1, 45877 }, -- The Boreal Guard
+				{ 2, 45887 }, -- Ice Layered Barrier
+			},
+		},
+		{
+			name = ALIL["Neck"],
+			[NORMAL_DIFF] = {
+				{ 1, 45933 }, -- Pendant of the Shallow Grave
+				{ 2, 45945 }, -- Seed of Budding Carnage
+				{ 3, 45447 }, -- Watchful Eye of Fate
+				{ 4, 46040 }, -- Strength of the Heavens
+				{ 5, 46047 }, -- Pendant of the Somber Witness
+			},
+		},
+		{
+			name = ALIL["Finger"],
+			[NORMAL_DIFF] = {
+				{ 1, 46046 }, -- Nebula Band
+				{ 2, 46096 }, -- Signet of Soft Lament
+				{ 3, 45946 }, -- Fire Orchid Signet
+				{ 4, 45297 }, -- Shimmering Seal
+				{16, 46048 }, -- Band of Lights
+				{17, 45456 }, -- Loop of the Agile
+				{19, 45871 }, -- Seal of Ulduar
+			},
+		},
+		{
+			name = ALIL["Trinket"],
+			[NORMAL_DIFF] = {
+				{ 1, 45931 }, -- Mjolnir Runestone
+				{ 2, 46038 }, -- Dark Matter
+				{ 3, 46051 }, -- Meteorite Crystal
+				{ 4, 45929 }, -- Sif's Remembrance
+			},
+		},
+		{
+			name = ALIL["Back"],
+			[NORMAL_DIFF] = {
+				{ 1, 46032 }, -- Drape of the Faceless General
+				{ 2, 46042 }, -- Drape of the Messenger
+			},
+		},
+		{
+			name = AL["Misc"],
+			[NORMAL_DIFF] = {
+				{ 1, 47556 }, -- Crusader Orb
+			},
+		},
+	}
+}
+
 -- shared!
 data["WorldEpicsWrath"] = {
 	name = AL["World Epics"],


### PR DESCRIPTION
This adds the data of the new Animated Constellation vendor which provides Sidereal Essence exchange.

Also updates the Emblem of Triumph vendor data.