### PR TITLE
Fix addon not loading on Classic Era 1.15.9 / TBC Anniversary 2.5.6

### DIFF
--- a/AtlasLootClassic/AtlasLootClassic.toc
+++ b/AtlasLootClassic/AtlasLootClassic.toc
@@ -40,6 +40,7 @@
 
 embeds.xml
 
+Compat.lua
 Init.lua
 Constants.lua
 db.lua

--- a/AtlasLootClassic/AtlasLootClassic_TBC.toc
+++ b/AtlasLootClassic/AtlasLootClassic_TBC.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 20504
+﻿## Interface: 20506
 ## Author: Lag
 ## Version: @project-version@
 ## SavedVariables: AtlasLootClassicDB
@@ -40,6 +40,7 @@
 
 embeds.xml
 
+Compat.lua
 Init.lua
 Constants.lua
 db.lua

--- a/AtlasLootClassic/AtlasLootClassic_Vanilla.toc
+++ b/AtlasLootClassic/AtlasLootClassic_Vanilla.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 11404
+﻿## Interface: 11509
 ## Author: Lag
 ## Version: @project-version@
 ## SavedVariables: AtlasLootClassicDB
@@ -40,6 +40,7 @@
 
 embeds.xml
 
+Compat.lua
 Init.lua
 Constants.lua
 db.lua

--- a/AtlasLootClassic/AtlasLootClassic_Wrath.toc
+++ b/AtlasLootClassic/AtlasLootClassic_Wrath.toc
@@ -40,6 +40,7 @@
 
 embeds.xml
 
+Compat.lua
 Init.lua
 Constants.lua
 db.lua

--- a/AtlasLootClassic/Button/Faction_type.lua
+++ b/AtlasLootClassic/Button/Faction_type.lua
@@ -339,7 +339,7 @@ function Faction.ShowToolTipFrame(button)
 		frame.standing.text:SetPoint("TOPLEFT", 3, -3)
 		frame.standing.text:SetPoint("BOTTOMRIGHT", -4, 3)
 		frame.standing.text:SetJustifyH("CENTER")
-		frame.standing.text:SetJustifyV("CENTER")
+		frame.standing.text:SetJustifyV("MIDDLE")
 		frame.standing.text:SetTextColor(1, 1, 1, 1)
 
 		frame.desc = frame:CreateFontString(name.."-desc", "ARTWORK", "GameFontNormalSmall")

--- a/AtlasLootClassic/Compat.lua
+++ b/AtlasLootClassic/Compat.lua
@@ -146,7 +146,14 @@ end
 if C_AddOns then
 	def("GetAddOnMetadata",    C_AddOns.GetAddOnMetadata)
 	def("GetAddOnInfo",        C_AddOns.GetAddOnInfo)
-	def("GetAddOnEnableState", C_AddOns.GetAddOnEnableState)
+	if _G.GetAddOnEnableState == nil and C_AddOns.GetAddOnEnableState then
+		-- NOTE: the argument order is swapped between the two:
+		-- old global: GetAddOnEnableState(character, addonIndexOrName)
+		-- new API:    C_AddOns.GetAddOnEnableState(addonIndexOrName, character)
+		_G.GetAddOnEnableState = function(character, addon)
+			return C_AddOns.GetAddOnEnableState(addon, character)
+		end
+	end
 	def("GetNumAddOns",        C_AddOns.GetNumAddOns)
 	def("IsAddOnLoaded",       C_AddOns.IsAddOnLoaded)
 	def("LoadAddOn",           C_AddOns.LoadAddOn)

--- a/AtlasLootClassic/Compat.lua
+++ b/AtlasLootClassic/Compat.lua
@@ -1,0 +1,167 @@
+-- ----------------------------------------------------------------------------
+-- AtlasLoot Compat
+--
+-- Classic Era 1.15.9 / TBC Anniversary 2.5.6 (July 2026) moved the client to
+-- the shared modern UI code base. Several globals AtlasLoot relied on were
+-- removed there:
+--   * LE_ITEM_CLASS_* / LE_ITEM_WEAPON_* / LE_ITEM_ARMOR_* / ... constants
+--     (now Enum.ItemClass, Enum.ItemWeaponSubclass, ...). Using them as table
+--     keys made Data/ClassFilter.lua fail with "table index is nil" and the
+--     whole addon stopped loading.
+--   * Old item / spell / addon API globals (GetItemInfo, GetSpellInfo,
+--     GetAddOnMetadata, ...) which now live in C_Item / C_Spell / C_AddOns.
+--
+-- This file only defines a global when it is missing, so it is a no-op on
+-- clients that still provide the old names.
+-- ----------------------------------------------------------------------------
+
+local function def(name, value)
+	if _G[name] == nil and value ~= nil then
+		_G[name] = value
+	end
+end
+
+local function defEnum(prefix, enumTable, map, fallback)
+	for legacy, key in pairs(map) do
+		local v = enumTable and enumTable[key]
+		if v == nil then v = fallback[legacy] end
+		def(prefix .. legacy, v)
+	end
+end
+
+-- ## Item classes -------------------------------------------------------------
+defEnum("LE_ITEM_CLASS_", Enum and Enum.ItemClass, {
+	CONSUMABLE = "Consumable", CONTAINER = "Container", WEAPON = "Weapon",
+	GEM = "Gem", ARMOR = "Armor", REAGENT = "Reagent", PROJECTILE = "Projectile",
+	TRADEGOODS = "Tradegoods", ITEM_ENHANCEMENT = "ItemEnhancement",
+	RECIPE = "Recipe", QUIVER = "Quiver", QUESTITEM = "Questitem",
+	KEY = "Key", MISCELLANEOUS = "Miscellaneous", GLYPH = "Glyph",
+	BATTLEPET = "Battlepet", WOW_TOKEN = "WoWToken",
+}, {
+	CONSUMABLE = 0, CONTAINER = 1, WEAPON = 2, GEM = 3, ARMOR = 4, REAGENT = 5,
+	PROJECTILE = 6, TRADEGOODS = 7, ITEM_ENHANCEMENT = 8, RECIPE = 9,
+	QUIVER = 11, QUESTITEM = 12, KEY = 13, MISCELLANEOUS = 15, GLYPH = 16,
+	BATTLEPET = 17, WOW_TOKEN = 18,
+})
+
+-- ## Weapon subclasses --------------------------------------------------------
+defEnum("LE_ITEM_WEAPON_", Enum and Enum.ItemWeaponSubclass, {
+	AXE1H = "Axe1H", AXE2H = "Axe2H", BOWS = "Bows", GUNS = "Guns",
+	MACE1H = "Mace1H", MACE2H = "Mace2H", POLEARM = "Polearm",
+	SWORD1H = "Sword1H", SWORD2H = "Sword2H", WARGLAIVE = "Warglaive",
+	STAFF = "Staff", BEARCLAW = "Bearclaw", CATCLAW = "Catclaw",
+	UNARMED = "Unarmed", GENERIC = "Generic", DAGGER = "Dagger",
+	THROWN = "Thrown", OBSOLETE3 = "Obsolete3", CROSSBOW = "Crossbow",
+	WAND = "Wand", FISHINGPOLE = "Fishingpole",
+}, {
+	AXE1H = 0, AXE2H = 1, BOWS = 2, GUNS = 3, MACE1H = 4, MACE2H = 5,
+	POLEARM = 6, SWORD1H = 7, SWORD2H = 8, WARGLAIVE = 9, STAFF = 10,
+	BEARCLAW = 11, CATCLAW = 12, UNARMED = 13, GENERIC = 14, DAGGER = 15,
+	THROWN = 16, OBSOLETE3 = 17, CROSSBOW = 18, WAND = 19, FISHINGPOLE = 20,
+})
+
+-- ## Armor subclasses ---------------------------------------------------------
+defEnum("LE_ITEM_ARMOR_", Enum and Enum.ItemArmorSubclass, {
+	GENERIC = "Generic", CLOTH = "Cloth", LEATHER = "Leather", MAIL = "Mail",
+	PLATE = "Plate", COSMETIC = "Cosmetic", SHIELD = "Shield",
+	LIBRAM = "Libram", IDOL = "Idol", TOTEM = "Totem", SIGIL = "Sigil",
+	RELIC = "Relic",
+}, {
+	GENERIC = 0, CLOTH = 1, LEATHER = 2, MAIL = 3, PLATE = 4, COSMETIC = 5,
+	SHIELD = 6, LIBRAM = 7, IDOL = 8, TOTEM = 9, SIGIL = 10, RELIC = 11,
+})
+
+-- ## Recipe subclasses --------------------------------------------------------
+defEnum("LE_ITEM_RECIPE_", Enum and Enum.ItemRecipeSubclass, {
+	BOOK = "Book", LEATHERWORKING = "Leatherworking", TAILORING = "Tailoring",
+	ENGINEERING = "Engineering", BLACKSMITHING = "Blacksmithing",
+	COOKING = "Cooking", ALCHEMY = "Alchemy", FIRST_AID = "FirstAid",
+	ENCHANTING = "Enchanting", FISHING = "Fishing",
+	JEWELCRAFTING = "Jewelcrafting", INSCRIPTION = "Inscription",
+}, {
+	BOOK = 0, LEATHERWORKING = 1, TAILORING = 2, ENGINEERING = 3,
+	BLACKSMITHING = 4, COOKING = 5, ALCHEMY = 6, FIRST_AID = 7,
+	ENCHANTING = 8, FISHING = 9, JEWELCRAFTING = 10, INSCRIPTION = 11,
+})
+
+-- ## Miscellaneous subclasses -------------------------------------------------
+defEnum("LE_ITEM_MISCELLANEOUS_", Enum and Enum.ItemMiscellaneousSubclass, {
+	JUNK = "Junk", REAGENT = "Reagent", COMPANION_PET = "CompanionPet",
+	HOLIDAY = "Holiday", OTHER = "Other", MOUNT = "Mount",
+	MOUNT_EQUIPMENT = "MountEquipment",
+}, {
+	JUNK = 0, REAGENT = 1, COMPANION_PET = 2, HOLIDAY = 3, OTHER = 4,
+	MOUNT = 5, MOUNT_EQUIPMENT = 6,
+})
+
+-- ## Item quality -------------------------------------------------------------
+local Q = Enum and Enum.ItemQuality
+def("LE_ITEM_QUALITY_POOR",      Q and Q.Poor or 0)
+def("LE_ITEM_QUALITY_COMMON",    Q and (Q.Common or Q.Standard) or 1)
+def("LE_ITEM_QUALITY_UNCOMMON",  Q and (Q.Uncommon or Q.Good) or 2)
+def("LE_ITEM_QUALITY_RARE",      Q and (Q.Rare or Q.Superior) or 3)
+def("LE_ITEM_QUALITY_EPIC",      Q and Q.Epic or 4)
+def("LE_ITEM_QUALITY_LEGENDARY", Q and Q.Legendary or 5)
+def("LE_ITEM_QUALITY_ARTIFACT",  Q and Q.Artifact or 6)
+def("LE_ITEM_QUALITY_HEIRLOOM",  Q and Q.Heirloom or 7)
+
+-- ## Expansion level ----------------------------------------------------------
+def("LE_EXPANSION_CLASSIC", 0)
+def("LE_EXPANSION_BURNING_CRUSADE", 1)
+def("LE_EXPANSION_WRATH_OF_THE_LICH_KING", 2)
+if _G.LE_EXPANSION_LEVEL_CURRENT == nil and GetExpansionLevel then
+	local ok, lvl = pcall(GetExpansionLevel)
+	if ok then def("LE_EXPANSION_LEVEL_CURRENT", lvl) end
+end
+
+-- ## Item API -----------------------------------------------------------------
+if C_Item then
+	def("GetItemInfo",         C_Item.GetItemInfo)
+	def("GetItemInfoInstant",  C_Item.GetItemInfoInstant)
+	def("GetItemCount",        C_Item.GetItemCount)
+	def("GetItemIcon",         C_Item.GetItemIconByID)
+	def("GetItemQualityColor", C_Item.GetItemQualityColor)
+	def("GetItemStats",        C_Item.GetItemStats)
+	def("GetItemSpell",        C_Item.GetItemSpell)
+	def("IsEquippableItem",    C_Item.IsEquippableItem)
+	def("GetItemFamily",       C_Item.GetItemFamily)
+end
+
+-- ## Spell API ----------------------------------------------------------------
+if C_Spell then
+	if _G.GetSpellInfo == nil and C_Spell.GetSpellInfo then
+		-- old signature: name, rank, icon, castTime, minRange, maxRange, spellID
+		_G.GetSpellInfo = function(spell)
+			local info = C_Spell.GetSpellInfo(spell)
+			if not info then return end
+			return info.name, nil, info.iconID, info.castTime, info.minRange, info.maxRange, info.spellID
+		end
+	end
+	def("GetSpellTexture",     C_Spell.GetSpellTexture)
+	def("GetSpellLink",        C_Spell.GetSpellLink)
+	def("GetSpellDescription", C_Spell.GetSpellDescription)
+end
+
+-- ## AddOn API ----------------------------------------------------------------
+if C_AddOns then
+	def("GetAddOnMetadata",    C_AddOns.GetAddOnMetadata)
+	def("GetAddOnInfo",        C_AddOns.GetAddOnInfo)
+	def("GetAddOnEnableState", C_AddOns.GetAddOnEnableState)
+	def("GetNumAddOns",        C_AddOns.GetNumAddOns)
+	def("IsAddOnLoaded",       C_AddOns.IsAddOnLoaded)
+	def("LoadAddOn",           C_AddOns.LoadAddOn)
+	def("EnableAddOn",         C_AddOns.EnableAddOn)
+	def("DisableAddOn",        C_AddOns.DisableAddOn)
+end
+
+-- ## Container API ------------------------------------------------------------
+if C_Container then
+	def("GetContainerNumSlots", C_Container.GetContainerNumSlots)
+	def("GetContainerItemID",   C_Container.GetContainerItemID)
+	def("GetContainerItemLink", C_Container.GetContainerItemLink)
+end
+
+-- ## Misc ---------------------------------------------------------------------
+if _G.GetMouseFocus == nil and GetMouseFoci then
+	_G.GetMouseFocus = function() local t = GetMouseFoci(); return t and t[1] end
+end

--- a/AtlasLootClassic/GUI/GUI.lua
+++ b/AtlasLootClassic/GUI/GUI.lua
@@ -1427,7 +1427,7 @@ function GUI:Create()
 	-- Center
 	-- #####
 	frame.contentFrame.searchBox = CreateFrame("EditBox", frameName.."-SearchBox", frame.contentFrame, "SearchBoxTemplate")
-	frame.contentFrame.searchBox:SetWidth(200)
+	frame.contentFrame.searchBox:SetWidth(150)
 	frame.contentFrame.searchBox:SetHeight(35)
 	frame.contentFrame.searchBox:SetPoint("CENTER", frame.contentFrame.downBG, "CENTER", 0, 0)
 	frame.contentFrame.searchBox:SetAutoFocus(false)

--- a/AtlasLootClassic/GUI/GUI.lua
+++ b/AtlasLootClassic/GUI/GUI.lua
@@ -118,9 +118,13 @@ local function UpdateFrames(noPageUpdate, forceContentUpdate)
 	if moduleData[dataID].items[bossID].npcID and SoundData:GetNpcData(moduleData[dataID].items[bossID].npcID) then
 		GUI.SoundFrame.npcID = moduleData[dataID].items[bossID].npcID
 		contentFrame.soundsButton:Show()
+		contentFrame.contentPhaseButton:ClearAllPoints()
+		contentFrame.contentPhaseButton:SetPoint("RIGHT", contentFrame.soundsButton, "LEFT", -5, 0)
 	else
 		GUI.SoundFrame.npcID = nil
 		contentFrame.soundsButton:Hide()
+		contentFrame.contentPhaseButton:ClearAllPoints()
+		contentFrame.contentPhaseButton:SetPoint("RIGHT", contentFrame.modelButton, "LEFT", -5, 0)
 		if contentFrame.shownFrame == GUI.SoundFrame.frame then
 			contentFrame.shownFrame = nil
 			if GUI.SoundFrame.frame then
@@ -1427,9 +1431,11 @@ function GUI:Create()
 	-- Center
 	-- #####
 	frame.contentFrame.searchBox = CreateFrame("EditBox", frameName.."-SearchBox", frame.contentFrame, "SearchBoxTemplate")
-	frame.contentFrame.searchBox:SetWidth(150)
 	frame.contentFrame.searchBox:SetHeight(35)
-	frame.contentFrame.searchBox:SetPoint("CENTER", frame.contentFrame.downBG, "CENTER", 0, 0)
+	-- span between the prev-page button and the (leftmost) content phase button
+	-- so it can never overlap the right-aligned button row
+	frame.contentFrame.searchBox:SetPoint("LEFT", frame.contentFrame.downBG, "LEFT", 45, 0)
+	frame.contentFrame.searchBox:SetPoint("RIGHT", frame.contentFrame.contentPhaseButton, "LEFT", -10, 0)
 	frame.contentFrame.searchBox:SetAutoFocus(false)
 	frame.contentFrame.searchBox:SetMaxLetters(50)
 	frame.contentFrame.searchBox:SetScript("OnEnterPressed", SearchBoxOnEnter)

--- a/AtlasLootClassic/GUI/GUI.lua
+++ b/AtlasLootClassic/GUI/GUI.lua
@@ -45,6 +45,15 @@ local function OnFavouritesAddonLoad(addon, enabled)
 	Favourites = enabled and addon or nil
 end
 
+-- grey out the button of the view (items / model / sounds) that is active
+local function UpdateViewButtonStates()
+	local contentFrame = GUI.frame.contentFrame
+	local shown = contentFrame.shownFrame
+	contentFrame.itemsButton:SetEnabled(not (shown and GUI.ItemFrame and shown == GUI.ItemFrame.frame))
+	contentFrame.modelButton:SetEnabled(not (shown and GUI.ModelFrame and shown == GUI.ModelFrame.frame))
+	contentFrame.soundsButton:SetEnabled(not (shown and GUI.SoundFrame and shown == GUI.SoundFrame.frame))
+end
+
 local function UpdateFrames(noPageUpdate, forceContentUpdate)
 	local moduleData = AtlasLoot.ItemDB:Get(db.selected[1])
 	if not moduleData then return end
@@ -148,6 +157,8 @@ local function UpdateFrames(noPageUpdate, forceContentUpdate)
 	else
 		contentFrame.searchBox:Hide()
 	end
+
+	UpdateViewButtonStates()
 
 	--[[ AtlasMapID
 	if AtlasLoot.AtlasIntegration and (AtlasLoot.AtlasIntegration.IsEnabled() and moduleData[dataID].AtlasMapID and AtlasLoot.AtlasIntegration.GetAtlasZoneData(moduleData[dataID].AtlasMapID)) then
@@ -1454,9 +1465,12 @@ function GUI:Create()
 	frame.contentFrame.prevPageButton.typ = "prev"
 
 	frame.contentFrame.itemsButton = GUI.CreateButton()
-	frame.contentFrame.itemsButton:SetPoint("LEFT", frame.contentFrame.prevPageButton, "RIGHT", 5, 0)
+	frame.contentFrame.itemsButton:SetPoint("RIGHT", frame.contentFrame.modelButton, "LEFT", -5, 0)
 	frame.contentFrame.itemsButton:SetText(AL["Items"])
 	frame.contentFrame.itemsButton:SetScript("OnClick", ItemButtonOnClick)
+	-- the sounds button moves left of the items button (it was anchored where
+	-- the items button now sits)
+	frame.contentFrame.soundsButton:SetPoint("RIGHT", frame.contentFrame.itemsButton, "LEFT", -5, 0)
 
 	-- Class Filter
 	frame.contentFrame.clasFilterButton = CreateFrame("Button", frameName.."-clasFilterButton")

--- a/AtlasLootClassic/GUI/GUI.lua
+++ b/AtlasLootClassic/GUI/GUI.lua
@@ -118,13 +118,9 @@ local function UpdateFrames(noPageUpdate, forceContentUpdate)
 	if moduleData[dataID].items[bossID].npcID and SoundData:GetNpcData(moduleData[dataID].items[bossID].npcID) then
 		GUI.SoundFrame.npcID = moduleData[dataID].items[bossID].npcID
 		contentFrame.soundsButton:Show()
-		contentFrame.contentPhaseButton:ClearAllPoints()
-		contentFrame.contentPhaseButton:SetPoint("RIGHT", contentFrame.soundsButton, "LEFT", -5, 0)
 	else
 		GUI.SoundFrame.npcID = nil
 		contentFrame.soundsButton:Hide()
-		contentFrame.contentPhaseButton:ClearAllPoints()
-		contentFrame.contentPhaseButton:SetPoint("RIGHT", contentFrame.modelButton, "LEFT", -5, 0)
 		if contentFrame.shownFrame == GUI.SoundFrame.frame then
 			contentFrame.shownFrame = nil
 			if GUI.SoundFrame.frame then
@@ -1431,11 +1427,9 @@ function GUI:Create()
 	-- Center
 	-- #####
 	frame.contentFrame.searchBox = CreateFrame("EditBox", frameName.."-SearchBox", frame.contentFrame, "SearchBoxTemplate")
+	frame.contentFrame.searchBox:SetWidth(150)
 	frame.contentFrame.searchBox:SetHeight(35)
-	-- span between the prev-page button and the (leftmost) content phase button
-	-- so it can never overlap the right-aligned button row
-	frame.contentFrame.searchBox:SetPoint("LEFT", frame.contentFrame.downBG, "LEFT", 45, 0)
-	frame.contentFrame.searchBox:SetPoint("RIGHT", frame.contentFrame.contentPhaseButton, "LEFT", -10, 0)
+	frame.contentFrame.searchBox:SetPoint("CENTER", frame.contentFrame.downBG, "CENTER", 0, 0)
 	frame.contentFrame.searchBox:SetAutoFocus(false)
 	frame.contentFrame.searchBox:SetMaxLetters(50)
 	frame.contentFrame.searchBox:SetScript("OnEnterPressed", SearchBoxOnEnter)

--- a/AtlasLootClassic/GUI/GUI.lua
+++ b/AtlasLootClassic/GUI/GUI.lua
@@ -1478,7 +1478,9 @@ function GUI:Create()
 	frame.contentFrame.clasFilterButton:RegisterForClicks("LeftButtonUp", "RightButtonUp");
 	frame.contentFrame.clasFilterButton:SetWidth(25)
 	frame.contentFrame.clasFilterButton:SetHeight(25)
-	frame.contentFrame.clasFilterButton:SetPoint("LEFT", frame.contentFrame.itemsButton, "RIGHT", 5, 0)
+	-- anchored to the prev page button (the items button moved to the right
+	-- side of the bar, next to the model button)
+	frame.contentFrame.clasFilterButton:SetPoint("LEFT", frame.contentFrame.prevPageButton, "RIGHT", 5, 0)
 	frame.contentFrame.clasFilterButton:SetScript("OnClick", ClassFilterButton_OnClick)
 	frame.contentFrame.clasFilterButton:SetScript("OnShow", ClassFilterButton_OnShow)
 	frame.contentFrame.clasFilterButton:SetScript("OnEnter", ClassFilterButton_OnEnter)

--- a/AtlasLootClassic/GUI/GUI.lua
+++ b/AtlasLootClassic/GUI/GUI.lua
@@ -1384,7 +1384,8 @@ function GUI:Create()
 	frame.contentFrame.contentPhaseButton:RegisterForClicks("LeftButtonUp", "RightButtonUp");
 	frame.contentFrame.contentPhaseButton:SetWidth(25)
 	frame.contentFrame.contentPhaseButton:SetHeight(25)
-	frame.contentFrame.contentPhaseButton:SetPoint("RIGHT", frame.contentFrame.modelButton, "LEFT", -5, 0)
+	-- anchored next to the class filter button below (created later),
+	-- previously it sat at the same point as the Sounds button and overlapped it
 	frame.contentFrame.contentPhaseButton:SetScript("OnClick", ContentPhaseButton_OnClick)
 	--frame.contentFrame.contentPhaseButton:SetScript("OnShow", ContentPhaseButton_OnShow)
 	--frame.contentFrame.contentPhaseButton:SetScript("OnEnter", ContentPhaseButton_OnEnter)
@@ -1470,6 +1471,8 @@ function GUI:Create()
 	frame.contentFrame.clasFilterButton:SetScript("OnLeave", ClassFilterButton_OnLeave)
 	frame.contentFrame.clasFilterButton.mainButton = true
 	--frame.contentFrame.clasFilterButton:Hide()
+
+	frame.contentFrame.contentPhaseButton:SetPoint("LEFT", frame.contentFrame.clasFilterButton, "RIGHT", 5, 0)
 
 	frame.contentFrame.clasFilterButton.texture = frame.contentFrame.clasFilterButton:CreateTexture(frameName.."-clasFilterButton-texture","ARTWORK")
 	frame.contentFrame.clasFilterButton.texture:SetAllPoints(frame.contentFrame.clasFilterButton)

--- a/AtlasLootClassic/GUI/ItemFrame.lua
+++ b/AtlasLootClassic/GUI/ItemFrame.lua
@@ -157,6 +157,9 @@ function ItemFrame:Refresh(skipProtect)
 	LastRefresh = GetTime()
 
 	ItemFrame:ClearItems()
+	-- incomplete selection (e.g. restored from saved variables of another
+	-- version, or nothing picked yet): nothing to refresh
+	if not (AtlasLoot.db.GUI.selected[1] and AtlasLoot.db.GUI.selected[2] and AtlasLoot.db.GUI.selected[3]) then return end
 	AtlasLoot.db.GUI.selected[5] = AtlasLoot.db.GUI.selected[5] or 0
 	ItemFrame.nextPage = nil
 	local page = AtlasLoot.db.GUI.selected[5] * 100 -- Page number for first items on a page are <1, 101, 201, 301, 401, ...>

--- a/AtlasLootClassic/GUI/ItemFrame.lua
+++ b/AtlasLootClassic/GUI/ItemFrame.lua
@@ -110,7 +110,10 @@ function ItemFrame.UpdateFilterItem(buttonID, reset)
 		local text = button.RawName or button.name:GetText()
 		if text and not sfind(slower(text), ItemFrame.SearchString, 1, true) then
 			button:SetAlpha(FILTER_ALPHA)
-		elseif reset then
+		elseif not AtlasLoot.db.GUI.classFilter then
+			-- always restore matches, otherwise buttons dimmed by a previous
+			-- search string stay dimmed when the search text changes
+			-- (with the class filter active its branch above set the alpha)
 			button:SetAlpha(1.0)
 		end
 		reset = false

--- a/AtlasLootClassic/GUI/SoundFrame.lua
+++ b/AtlasLootClassic/GUI/SoundFrame.lua
@@ -117,7 +117,7 @@ local function CreateSoundButtons()
 		frame.name:SetPoint("RIGHT", frame.play, "LEFT")
 		frame.name:SetHeight(28)
 		frame.name:SetJustifyH("LEFT")
-		frame.name:SetJustifyV("CENTER")
+		frame.name:SetJustifyV("MIDDLE")
 		frame.name:SetText("Sound.name")
 
 		if i==1 then

--- a/AtlasLootClassic/GUI/Template_CheckBox.lua
+++ b/AtlasLootClassic/GUI/Template_CheckBox.lua
@@ -43,7 +43,7 @@ function GUI.CreateCheckBox()
 	self.onClickFunc = nil	-- Run on OnClick
 	self.checked = false
 
-	self.frame = CreateFrame("CheckButton", frameName, nil, "OptionsCheckButtonTemplate")
+	self.frame = CreateFrame("CheckButton", frameName, nil, "UICheckButtonTemplate")
 	self.frame:SetWidth(25)
 	self.frame:SetHeight(25)
 	self.frame:SetScript("OnClick", OnClick)

--- a/AtlasLootClassic/ItemDB/ItemDB.lua
+++ b/AtlasLootClassic/ItemDB/ItemDB.lua
@@ -241,9 +241,9 @@ local function loadItemsFromOtherModule(moduleLoader, loadString, contentTable, 
 end
 
 function ItemDB:GetItemTable(addonName, contentName, boss, dif)
-	assert(addonName and ItemDB.Storage[addonName], addonName.." (addonName) not found!")
-	assert(contentName and ItemDB.Storage[addonName][contentName], contentName.." (contentName) not found!")
-	assert(boss and ItemDB.Storage[addonName][contentName].items[boss], boss.." (boss) not found!")
+	assert(addonName and ItemDB.Storage[addonName], tostring(addonName).." (addonName) not found!")
+	assert(contentName and ItemDB.Storage[addonName][contentName], tostring(contentName).." (contentName) not found!")
+	assert(boss and ItemDB.Storage[addonName][contentName].items[boss], tostring(boss).." (boss) not found!")
 	local addonNameRETVALUE, addon
 	if ItemDB.Storage[addonName][contentName].items[boss].link then
 		return ItemDB:GetItemTable(ItemDB.Storage[addonName][contentName].items[boss].link[1], ItemDB.Storage[addonName][contentName].items[boss].link[2], ItemDB.Storage[addonName][contentName].items[boss].link[3], dif)

--- a/AtlasLootClassic_Collections/AtlasLootClassic_Collections_TBC.toc
+++ b/AtlasLootClassic_Collections/AtlasLootClassic_Collections_TBC.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 20504
+﻿## Interface: 20506
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/AtlasLootClassic_Collections/AtlasLootClassic_Collections_Vanilla.toc
+++ b/AtlasLootClassic_Collections/AtlasLootClassic_Collections_Vanilla.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 11404
+﻿## Interface: 11509
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/AtlasLootClassic_Crafting/AtlasLootClassic_Crafting_TBC.toc
+++ b/AtlasLootClassic_Crafting/AtlasLootClassic_Crafting_TBC.toc
@@ -1,4 +1,4 @@
-## Interface: 20504
+## Interface: 20506
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/AtlasLootClassic_Crafting/AtlasLootClassic_Crafting_Vanilla.toc
+++ b/AtlasLootClassic_Crafting/AtlasLootClassic_Crafting_Vanilla.toc
@@ -1,4 +1,4 @@
-## Interface: 11404
+## Interface: 11509
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/AtlasLootClassic_Data/AtlasLootClassic_Data_TBC.toc
+++ b/AtlasLootClassic_Data/AtlasLootClassic_Data_TBC.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 20504
+﻿## Interface: 20506
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/AtlasLootClassic_Data/AtlasLootClassic_Data_Vanilla.toc
+++ b/AtlasLootClassic_Data/AtlasLootClassic_Data_Vanilla.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 11404
+﻿## Interface: 11509
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/AtlasLootClassic_DungeonsAndRaids/AtlasLootClassic_DungeonsAndRaids_TBC.toc
+++ b/AtlasLootClassic_DungeonsAndRaids/AtlasLootClassic_DungeonsAndRaids_TBC.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 20504
+﻿## Interface: 20506
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/AtlasLootClassic_DungeonsAndRaids/AtlasLootClassic_DungeonsAndRaids_Vanilla.toc
+++ b/AtlasLootClassic_DungeonsAndRaids/AtlasLootClassic_DungeonsAndRaids_Vanilla.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 11404
+﻿## Interface: 11509
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/AtlasLootClassic_Factions/AtlasLootClassic_Factions_TBC.toc
+++ b/AtlasLootClassic_Factions/AtlasLootClassic_Factions_TBC.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 20504
+﻿## Interface: 20506
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/AtlasLootClassic_Factions/AtlasLootClassic_Factions_Vanilla.toc
+++ b/AtlasLootClassic_Factions/AtlasLootClassic_Factions_Vanilla.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 11404
+﻿## Interface: 11509
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/AtlasLootClassic_Options/AtlasLootClassic_Options_TBC.toc
+++ b/AtlasLootClassic_Options/AtlasLootClassic_Options_TBC.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 20504
+﻿## Interface: 20506
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/AtlasLootClassic_Options/AtlasLootClassic_Options_Vanilla.toc
+++ b/AtlasLootClassic_Options/AtlasLootClassic_Options_Vanilla.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 11404
+﻿## Interface: 11509
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/AtlasLootClassic_PvP/AtlasLootClassic_PvP_TBC.toc
+++ b/AtlasLootClassic_PvP/AtlasLootClassic_PvP_TBC.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 20504
+﻿## Interface: 20506
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/AtlasLootClassic_PvP/AtlasLootClassic_PvP_Vanilla.toc
+++ b/AtlasLootClassic_PvP/AtlasLootClassic_PvP_Vanilla.toc
@@ -1,4 +1,4 @@
-﻿## Interface: 11404
+﻿## Interface: 11509
 ## Author: Lag
 ## Version: @project-version@
 ## Dependencies: AtlasLootClassic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This mod is distributed under Version 2 of the GPL.  A copy of the GPL is includ
 
 [Changelog history](https://github.com/Hoizame/AtlasLootClassic/blob/master/AtlasLootClassic/Documentation/Release_Notes.md)
 
+## v3.2.1 (Aug. 24, 2026)
+
+- Fix addon not loading on Classic Era 1.15.9 / TBC Anniversary 2.5.6: `Data/ClassFilter.lua:62: table index is nil` (issues #481, #483). The `LE_ITEM_*` / `LE_EXPANSION_*` globals were removed from the client; new `Compat.lua` maps them from `Enum.*` and polyfills removed item/spell/addon API globals via `C_Item` / `C_Spell` / `C_AddOns`.
+- Fix Favourites window error `Couldn't find inherited node "OptionsCheckButtonTemplate"` (issues #458, #472) - use `UICheckButtonTemplate`.
+- Fix `bad argument #1 to 'SetJustifyV'` in faction tooltips and sound frame (issue #472) - `"CENTER"` -> `"MIDDLE"`.
+- Update .toc Interface versions: Vanilla 11509, TBC 20506.
+
 ## v3.2.0 (Oct. 22, 2023)
 
 - update .toc version

--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@
 
 AtlasLootClassic is an UI mod allowing for loot tables of bosses to be browsed whenever needed within the game.
 
-## Download
+> **This fork (branch `fix/2026-classic-era`) fixes the addon for WoW Classic Era / Hardcore patch 1.15.9 (July 2026)**, where the original stopped loading with `ClassFilter.lua:62: table index is nil`. The fixes have been submitted upstream as [PR #485](https://github.com/Hoizame/AtlasLootClassic/pull/485). All credit for the original addon goes to its authors.
+
+## Download (fixed version)
+
+* **[Latest release zip](https://github.com/scotjam/AtlasLootClassic/releases/latest)** (manual install, see below)
+* [CurseForge: AtlasLoot Classic Era Aug 2026](https://www.curseforge.com/wow/addons/atlasloot-classic-era-aug-2026) (pending moderation)
+
+## Manual install
+
+1. Close World of Warcraft.
+2. Download the zip from the [latest release](https://github.com/scotjam/AtlasLootClassic/releases/latest).
+3. Delete any existing `AtlasLootClassic*` folders from `World of Warcraft\_classic_era_\Interface\AddOns\` (other AtlasLoot versions use the same folder names and will conflict). Your favourites and settings are stored in `WTF\` and are **not** affected.
+4. Extract the zip and copy all **8** `AtlasLootClassic*` folders into `World of Warcraft\_classic_era_\Interface\AddOns\`.
+5. Start the game - you should see 8 AtlasLootClassic entries in the AddOns list. Open the loot browser with `/al` or the minimap button.
+
+## Original download links (broken on Era 1.15.9)
 
 [Curseforge](https://www.curseforge.com/wow/addons/atlaslootclassic)
 


### PR DESCRIPTION
## Problem

Since the July 2026 client update (Classic Era **1.15.9** / TBC Anniversary **2.5.6**), the addon fails on login with

```
Data/ClassFilter.lua:62: table index is nil
```

and never loads (fixes #481, #483). The client moved to the shared modern UI code base, which removed the `LE_ITEM_*` / `LE_EXPANSION_*` globals that `ClassFilter.lua` uses as table keys, along with several old API globals.

## Fixes

- **New `Compat.lua`** (loaded before `Init.lua`): defines the missing `LE_ITEM_*` / `LE_ITEM_QUALITY_*` / `LE_EXPANSION_*` constants from `Enum.*` and polyfills removed globals (`GetItemInfo`, `GetSpellInfo`, `GetAddOnMetadata`, `GetAddOnEnableState` with its swapped argument order, ...) from `C_Item` / `C_Spell` / `C_AddOns` / `C_Container`. Every definition is guarded so older clients are unaffected.
- Favourites window: `OptionsCheckButtonTemplate` no longer exists → `UICheckButtonTemplate` (fixes #458, #472).
- `SetJustifyV("CENTER")` is rejected by the new client → `"MIDDLE"` (fixes part of #472).
- `.toc` Interface bumped to 11509 (Vanilla) / 20506 (TBC).
- Fix error in `ItemDB:GetItemTable` / `ItemFrame:Refresh` when the restored GUI selection is incomplete.
- Fix search filter leaving items dimmed from a previous search string after the text changes.
- Small bottom-bar layout cleanups: content phase icon no longer overlaps the Sounds button; Items grouped with the other view buttons and the active view greyed out.

Tested in-game on Classic Era 1.15.9.69109: modules load, browsing, search, favourites and the phase/class filters work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYDJiMS2Y4RhtkbjRG8do8